### PR TITLE
Only audits the fields that are not autoRef

### DIFF
--- a/customize.js
+++ b/customize.js
@@ -1,3 +1,3 @@
 module.exports = {
-  version: "1.1.20"
+  version: "1.2.0"
 }

--- a/integrationm/.gitignore
+++ b/integrationm/.gitignore
@@ -1,0 +1,22 @@
+.DS_Store
+node_modules
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+**/*.iml
+
+target/

--- a/integrationm/common/com/cultofbits/customizations/audit/AuditInstanceUpdater.groovy
+++ b/integrationm/common/com/cultofbits/customizations/audit/AuditInstanceUpdater.groovy
@@ -1,0 +1,157 @@
+package com.cultofbits.customizations.audit
+
+import com.cultofbits.integrationm.service.actionpack.RecordmActionPack
+import com.cultofbits.integrationm.service.actionpack.UsermActionPack
+import com.google.common.cache.Cache
+import com.cultofbits.integrationm.service.dictionary.recordm.Definition
+import com.cultofbits.integrationm.service.dictionary.recordm.FieldDefinition
+import com.cultofbits.integrationm.service.dictionary.recordm.RecordmMsg
+import com.google.common.cache.CacheBuilder
+import org.json.JSONObject
+
+class AuditInstanceUpdater {
+
+    private static Cache<String, Definition> globalCache;
+
+    protected static Cache<String, Definition> getCache(){
+        if (globalCache == null){
+            globalCache = CacheBuilder.newBuilder()
+                    .maximumSize(100)
+                    .build()
+        }
+        return globalCache
+    }
+
+
+
+    private final RecordmActionPack recordmActionPack
+    private final UsermActionPack usermActionPack
+    private final Cache<String, Definition> cacheOfAuditFieldsForDefinition
+    private final Object log
+
+    AuditInstanceUpdater(RecordmActionPack recordmActionPack, UsermActionPack usermActionPack, log) {
+        cacheOfAuditFieldsForDefinition = getCache()
+        this.recordmActionPack = recordmActionPack
+        this.usermActionPack = usermActionPack
+        this.log = log
+    }
+
+    Definition getDefinitionFromCache(RecordmMsg msg) {
+        Definition definition = cacheOfAuditFieldsForDefinition.get(msg.type, { recordmActionPack.getDefinition(msg.getDefinitionName()).getBody() })
+
+        if (definition.getVersion() != msg.getDefinitionVersion()) {
+            cacheOfAuditFieldsForDefinition.invalidate(msg.type)
+            definition = cacheOfAuditFieldsForDefinition.get(msg.type, { recordmActionPack.getDefinition(msg.getDefinitionName()).getBody() })
+        }
+
+        return definition
+    }
+
+    def getAuditFields(RecordmMsg msg) {
+        Definition definition = getDefinitionFromCache(msg)
+
+        def nonRefFieldChanged = false
+
+        def regex = /[$]audit\.(creator|updater)\.(username|uri|time)/
+        def auditFields = [];
+        for (FieldDefinition fd in definition.fieldDefinitions) {
+            System.out.println(".. " + msg.field(fd.name).changed() + " --- "+ fd.name );
+            if (msg.field(fd.name).changed() && !fd.configuration.keys.containsKey("AutoRefField")) {
+                nonRefFieldChanged = true
+                break
+            }
+        }
+        for (FieldDefinition fd in definition.fieldDefinitions) {
+            def matcher = fd =~ regex
+            if (matcher) {
+                if (msg.action == 'update' && !nonRefFieldChanged && ignoreRefsChanges(fd.configuration.extensions)) continue
+                def op = matcher[0][1]
+                def arg = matcher[0][2]
+                auditFields << [fieldId: fd.id, name: fd.name, op: op, args: arg]
+            }
+        }
+
+        log?.info("[\$audit] Update 'auditFields' for '${msg.getDefinitionName()}': $auditFields");
+
+        return auditFields
+    }
+
+     /***
+     *
+     * @return a map of the fields that changed. The map is <fieldName,(username|uri|time)>
+     * @username: username of the user that changed the value of the field
+     * @uri: uri of the user that changed the value of the field
+     * @time: time of when the field value was update or changed
+     */
+    def LinkedHashMap<String, String> getAuditFieldsUpdates(auditFields, RecordmMsg msg) {
+        LinkedHashMap<String, String> updates = [:]
+
+        auditFields.each { auditField ->
+            if (auditField.op == "creator" && msg.action == "update" && msg.value(auditField.name) != null) {
+                // 'creator' fields are only changed in 'update' if the previous value was empty (meaning it was a field that was not visible)
+                return
+            }
+
+            if (auditField.args == "uri") {
+                updates << [(auditField.name): usermActionPack.getUser(msg.user).data._links.self]
+            } else if (auditField.args == "username") {
+                updates << [(auditField.name): msg.user]
+            } else if (auditField.args == "time") {
+                if (msg.action == 'add' && msg.value(auditField.name, Long.class) ?: msg.getTimestamp() < 30000) return
+                // Ignore changes less then 30s
+                updates << [(auditField.name): "" + msg.getTimestamp()]
+            }
+        }
+
+        return updates
+    }
+
+    /**
+     * @return true if the JSONObject extraKeywords has an audit description with an argument of ignoreRefs:true
+     * Example: $audit.updater.time(ignoreRefs:true)
+     */
+    def private static ignoreRefsChanges(Map extraKeywords) {
+        def rgx = /[$]audit\.(creator|updater)\.(username|uri|time)/
+
+        for (def key in extraKeywords.keySet()) {
+            if (key =~ rgx) {
+                JSONObject jsonObj = new JSONObject(extraKeywords.get(key))
+                if (jsonObj.has("args")) {
+                    def args = jsonObj.getJSONArray("args")
+                    if (args.length() > 0) {
+                        return toMapArgs(args.optString(0))["ignoreRefs"] == "true"
+                    }
+                }
+                return false
+            }
+        }
+        return false
+    }
+
+    /**
+     * @stringArgs a string with the options of audit. Eg.:"[ignoreRefs:true,a:1]"
+     * @return a map containing the elements in the string
+     * */
+    def private static toMapArgs(stringArgs) {
+        if (stringArgs == null) {
+            return [:]
+        }
+        return stringArgs
+                .replaceAll("^\\[", "")
+                .replaceAll("]\$", "")
+                .replaceAll("\\\\,", "@COB_ENC_COMMA@")
+                .replaceAll("\\\\:", "@COB_ENC_COLON@")
+                .split(",")
+                .collectEntries {
+                    it = it.split(":")
+                    if (it.length > 1) {
+                        [it[0].trim(),
+                         it[1].trim()
+                                 .replaceAll("@COB_ENC_COMMA@", ",")
+                                 .replaceAll("@COB_ENC_COLON@", ":")]
+                    } else {
+                        [:]
+                    }
+                };
+    }
+}

--- a/integrationm/pom.xml
+++ b/integrationm/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.cultofbits.customizations</groupId>
+    <artifactId>integrationm-audit</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>$audit</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.15</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cultofbits.integrationm</groupId>
+            <artifactId>integrationm-service</artifactId>
+            <version>[14.3.0-SNAPSHOT,)</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>1.1-groovy-2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sources>
+                        <source>
+                            <directory>${project.basedir}/common</directory>
+                        </source>
+                        <source>
+                            <directory>${project.basedir}/scripts</directory>
+                        </source>
+                    </sources>
+                    <testSources>
+                        <testSource>
+                            <directory>${project.basedir}/test</directory>
+                        </testSource>
+                    </testSources>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integrationm/scripts/_audit.groovy
+++ b/integrationm/scripts/_audit.groovy
@@ -1,77 +1,15 @@
 import groovy.transform.Field
-import org.codehaus.jettison.json.JSONObject
+import com.cultofbits.customizations.audit.AuditInstanceUpdater
 
-import com.google.common.cache.*
-import java.util.concurrent.TimeUnit
+if (msg.user == "integrationm") return
 
-if (msg.product != "recordm-definition" && msg.product != "recordm" ) return
+@Field def auditInstanceUpdated = new AuditInstanceUpdater(recordm, userm, log)
 
-@Field static cacheOfAuditFieldsForDefinition = CacheBuilder.newBuilder()
-        .expireAfterWrite(5, TimeUnit.MINUTES)
-        .build();
-
-if (msg.product == "recordm-definition") cacheOfAuditFieldsForDefinition.invalidate(msg.type)
-
-// ========================================================================================================
-def auditFields = cacheOfAuditFieldsForDefinition.get(msg.type, { getAuditFields(msg.type) })
-if (msg.user != "integrationm" && auditFields.size() > 0 && msg.product == "recordm" && msg.action =~ "add|update") {
-    if (msg.action == "add" || msg.instance.fields.any { f -> msg.field(f.fieldDefinition.name).changed() }) {
-        def updatedFields = getAuditFieldsUpdates(auditFields, msg.instance.fields)
+if (msg.product == "recordm" && msg.action =~ "add|update") {
+    def auditFields = auditInstanceUpdated.getAuditFields(msg)
+    def updatedFields = auditInstanceUpdated.getAuditFieldsUpdates(auditFields,msg)
+    if (updatedFields.size() > 0) {
         log.info("[_\$audit] Updating audit fields for instance ${msg.instance.id} updatedFields=${updatedFields}")
-
         recordm.update(msg.type, msg.instance.id, updatedFields);
     }
-}
-
-// ========================================================================================================
-def getAuditFieldsUpdates(auditFields,instanceFields) {
-    def updates = [:]
-    auditFields.each { auditField ->
-        if( auditField.op == "creator" && msg.action == "update" && msg.value(auditField.name) != null) return // 'creator' fields are only changed in 'update' if the previous value was empty (meaning it was a field that was not visible)
-        if( msg.action == 'update' && !msg.diff) return // Only continues if there is at least one change
-        if( auditField.args == "uri") {
-            updates << [(auditField.name) : actionPacks.get("userm").getUser(msg.user).data._links.self]
-
-        } else if( auditField.args == "username") {
-            updates << [(auditField.name) : msg.user]
-
-        } else if( auditField.args == "time") {
-            if(msg.action == 'add' && Math.abs(msg.value(auditField.name, Long.class)?:0 - msg._timestamp_) < 30000) return // Ignore changes less then 30s
-            updates << [(auditField.name) : "" + msg._timestamp_]
-        }
-    }
-    return updates
-}
-
-def getAuditFields(definitionName) {
-    // Obtém detalhes da definição
-    def definitionEncoded = URLEncoder.encode(definitionName, "utf-8").replace("+", "%20")
-    def resp = actionPacks.rmRest.get( "recordm/definitions/name/${definitionEncoded}".toString(), [:], "integrationm");
-    JSONObject definition = new JSONObject(resp);
-
-    def fieldsSize = definition.fieldDefinitions.length();
-
-    def fields = [:]
-    (0..fieldsSize-1).each { index ->
-        def fieldDefinition  = definition.fieldDefinitions.getJSONObject(index)
-        def fieldDescription = fieldDefinition.optString("description")
-        if(fieldDescription){
-            def fieldDefId       = fieldDefinition.get("id");
-            def fieldName        = fieldDefinition.get("name");
-            fields[fieldDefId]   = [name:fieldName, description: fieldDescription]
-        }
-    }
-
-    // Finalmente obtém a lista de campos que é necessário calcular
-    def auditFields = [];
-    fields.each { fieldId,field ->
-        def matcher = field.description =~ /[$]audit\.(creator|updater)\.(username|uri|time)/
-        if(matcher) {
-            def op = matcher[0][1]
-            def arg = matcher[0][2]
-            auditFields << [fieldId: fieldId, name:field.name, op : op, args: arg]
-        }
-    }
-    log.info("[\$audit] Update 'auditFields' for '$definitionName': $auditFields");
-    return auditFields
 }

--- a/integrationm/test/com/cultofbits/customizations/audit/AuditUtilsTest.groovy
+++ b/integrationm/test/com/cultofbits/customizations/audit/AuditUtilsTest.groovy
@@ -1,0 +1,246 @@
+package com.cultofbits.customizations.audit
+
+import com.cultofbits.customizations.utils.FieldDefinitionBuilder
+import com.cultofbits.integrationm.service.actionpack.RecordmActionPack
+import com.cultofbits.integrationm.service.dictionary.ReusableResponse
+import com.cultofbits.customizations.utils.RecordmMsgBuilder
+import com.cultofbits.integrationm.service.dictionary.recordm.Definition
+import com.cultofbits.integrationm.service.dictionary.recordm.FieldDefinition
+import com.cultofbits.integrationm.service.dictionary.recordm.RecordmMsg
+import spock.lang.Specification
+
+import static com.cultofbits.customizations.utils.DefinitionBuilder.aDefinition
+import static com.cultofbits.customizations.utils.FieldDefinitionBuilder.aFieldDefinition
+
+class AuditUtilsTest extends Specification {
+
+    def getDefinition() {
+        return aDefinition()
+                .id(1)
+                .name("Audit Definition")
+                .fieldDefinitions(
+                        aFieldDefinition().id(11).name("Text").description("\$text"),
+                        aFieldDefinition().id(12).name("Creator").description("\$audit.creator.username"),
+                        aFieldDefinition().id(13).name("TimeCreation").description("\$audit.updater.time"),
+                        aFieldDefinition().id(14).name("RefField").description("")
+                                .setConfigurationKey("AutoRefField", "{\"args\":{\"source_field\":\"client\",\"field_name\":\"age\"}}")
+                )
+    }
+
+    def getDefinition(String name) {
+        def definition = getDefinition()
+        definition.name = name
+        return definition
+    }
+
+    def FieldDefinition buildFieldDefinition(int fieldId, String fieldName, String fieldDescription, String fieldConfigurationKey, String fieldConfiguration) {
+        FieldDefinitionBuilder builder = aFieldDefinition()
+                .id(fieldId)
+                .name(fieldName)
+                .description(fieldDescription)
+
+        if (fieldConfiguration != null) {
+            builder.setConfigurationExtensions(fieldConfigurationKey, fieldConfiguration);
+        }
+
+        return builder.build()
+    }
+
+    def "can detect \$audit fields on add"() {
+
+        def definition = getDefinition().build()
+        def newInstanceMsg = RecordmMsgBuilder.aMessage("cob-admin", definition, "add")
+                .build()
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definition), null, null)
+
+        def auditFields = auditInstanceUpdated.getAuditFields(newInstanceMsg)
+
+        expect:
+        auditFields.size() == 2
+        auditFields[0].name == "Creator"
+        auditFields[1].name == "TimeCreation"
+    }
+
+    def "can detect \$audit fields on update with no audit arguments"() {
+
+        def definition = getDefinition().build()
+
+        //audit without arguments
+        def newInstanceMsg = RecordmMsgBuilder.aMessage("cob-admin", definition, "update").newField(definition.getFirstField("Text"), "text")
+                .build()
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definition), null, null)
+
+        def auditFields = auditInstanceUpdated.getAuditFields(newInstanceMsg)
+
+        expect:
+        auditFields.size() == 2
+        auditFields[0].name == "Creator"
+        auditFields[1].name == "TimeCreation"
+
+    }
+
+    def "can detect \$audit fields on update with audit arguments [ignoreRefs:false,a:1] or [ignoreRefs:true,a:1]"() {
+
+        def definitionBuilder = getDefinition()
+
+        def definition = definitionBuilder.addFieldDefinitions(
+                buildFieldDefinition(14, "TimeCreation2", "\$audit.updater.uri([ignoreRefs:false,a:1])", "\$audit.updater.uri", "{\"args\":[\"[ignoreRefs:false,a:1]\"]}"),
+                buildFieldDefinition(16, "TimeCreation3", "\$audit.updater.username([ignoreRefs:true,a:1])", "\$audit.updater.username", "{\"args\":[\"[ignoreRefs:true,a:1]\"]}")
+        ).build();
+
+
+        //audit without arguments
+        def newInstanceMsg = RecordmMsgBuilder.aMessage("cob-admin", definition, "update").newField(definition.getFirstField("Text"), "text")
+                .build()
+        RecordmMsg.Field f = Mock(RecordmMsg.Field.class)
+        f.changed() >> false
+        newInstanceMsg.field("") >> f
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definition), null, null)
+
+
+        def auditFields = auditInstanceUpdated.getAuditFields(newInstanceMsg)
+
+        expect:
+        definition.rootFields.size() == 6
+        auditFields.size() == 4
+        auditFields[0].name == "Creator"
+        auditFields[0].op == "creator"
+        auditFields[0].args == "username"
+
+
+        auditFields[1].name == "TimeCreation"
+        auditFields[1].op == "updater"
+        auditFields[1].args == "time"
+
+
+        auditFields[2].name == "TimeCreation2"
+        auditFields[2].op == "updater"
+        auditFields[2].args == "uri"
+
+
+        auditFields[3].name == "TimeCreation3"
+        auditFields[3].op == "updater"
+        auditFields[3].args == "username"
+    }
+
+    def "when none of the nonRef fields change and ignore audit is true"() {
+        def definitionBuilder = getDefinition()
+
+        def definition = definitionBuilder.addFieldDefinitions(
+                buildFieldDefinition(14, "TimeCreation2", "\$audit.updater.uri([ignoreRefs:false,a:1])", "\$audit.updater.time", "{\"args\":[\"[ignoreRefs:false,a:1]\"]}"),
+                buildFieldDefinition(16, "TimeCreation3", "\$audit.updater.username([ignoreRefs:true,a:1])", "\$audit.updater.time", "{\"args\":[\"[ignoreRefs:true,a:1]\"]}")
+        ).build();
+
+        RecordmMsg newInstanceMsg = RecordmMsgBuilder.aMessage("cob-admin", definition, "update").build()
+        RecordmMsg.Field f = Stub()
+        f.changed() >> false
+        newInstanceMsg.field("") >> f
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definition), null, null)
+
+        def auditFields = auditInstanceUpdated.getAuditFields(newInstanceMsg)
+
+        expect:
+        auditFields.size() == 3
+    }
+
+    def "when at least one nonRef field changes and ignore audit is true"() {
+        def definitionBuilder = getDefinition()
+
+        def definition = definitionBuilder.addFieldDefinitions(
+                buildFieldDefinition(15, "TimeCreation2", "\$audit.updater.uri([ignoreRefs:false,a:1])", null, null),
+                buildFieldDefinition(16, "TimeCreation3", "\$audit.updater.username([ignoreRefs:true,a:1])", null, null)
+        ).build();
+
+        //audit without arguments
+        def newInstanceMsg = RecordmMsgBuilder.aMessage("cob-admin", definition, "update").newField(definition.getFirstField("Text"), "text")
+                .updatedField(definition.getField(11), "oldValue", "")
+                .build()
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definition), null, null)
+
+        def auditFields = auditInstanceUpdated.getAuditFields(newInstanceMsg)
+
+        expect:
+        auditFields.size() == 4
+    }
+
+    def "getAuditFieldsUpdates"() {
+        def definitionBuilder = getDefinition()
+        def definition = definitionBuilder.build()
+
+        def auditFields = [];
+
+        auditFields << [fieldId: 1, name: "field7", op: "updater", args: "time"]
+        auditFields << [fieldId: 3, name: "field9", op: "updater", args: "username"]
+
+        def newInstanceMsg = Mock(RecordmMsg.class)
+        newInstanceMsg.getTimestamp() >> System.currentTimeMillis()
+        newInstanceMsg.value("any value") >> null
+        newInstanceMsg.action >> "add"
+        newInstanceMsg.user >> "any user"
+        newInstanceMsg.value("any value", Long.class) >> Long.valueOf(12000000000L)
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definitionBuilder.build()), null, null)
+
+        def fieldsToUpdate = auditInstanceUpdated.getAuditFieldsUpdates(auditFields, newInstanceMsg)
+
+        expect:
+        fieldsToUpdate.size() == 2
+    }
+
+    def "test cache"() {
+        def cache = AuditInstanceUpdater.getCache()
+
+        def definition = getDefinition().build()
+
+        def cachedDefinition1 = getCachedDefinitionAux(definition)
+
+        expect:
+        cache != null
+        cache.size() == 1
+        cachedDefinition1.hashCode() == definition.hashCode()
+    }
+    RecordmActionPack getRecordmActionPack(definition){
+        def reusableResponse = Stub(ReusableResponse.class)
+        reusableResponse.getBody() >> definition
+
+        def rmActionPack = Stub(RecordmActionPack.class)
+        rmActionPack.getDefinition(definition.name) >> reusableResponse
+
+        return rmActionPack
+    }
+    def getCachedDefinitionAux(Definition definition) {
+
+        def rmActionPack = getRecordmActionPack(definition)
+
+        def newInstanceMsg = RecordmMsgBuilder.aMessage("cob-admin", definition, "update").newField(definition.getFirstField("Text"), "text")
+                .build()
+
+        AuditInstanceUpdater auditInstanceUpdated = new AuditInstanceUpdater(getRecordmActionPack(definition), null, null)
+
+        return auditInstanceUpdated.getDefinitionFromCache(newInstanceMsg)
+    }
+
+    def "test cache different definition version"() {
+        def cache = AuditInstanceUpdater.getCache()
+
+        def definition = getDefinition().build()
+
+        def cachedDefinition1 = getCachedDefinitionAux(definition)
+
+        // second definition
+        def definitionSecond = getDefinition().build()
+        definitionSecond.version = 14
+
+        def cachedDefinitionSecond = getCachedDefinitionAux(definitionSecond)
+        expect:
+        cache.size() == 1
+        cachedDefinition1.version == definition.version
+        cachedDefinitionSecond.version == definitionSecond.version
+        cachedDefinition1.version != cachedDefinitionSecond.version
+    }
+}

--- a/integrationm/test/com/cultofbits/customizations/utils/DefinitionBuilder.groovy
+++ b/integrationm/test/com/cultofbits/customizations/utils/DefinitionBuilder.groovy
@@ -1,0 +1,79 @@
+package com.cultofbits.customizations.utils
+
+import com.cultofbits.integrationm.service.dictionary.recordm.Definition
+import com.cultofbits.integrationm.service.dictionary.recordm.FieldDefinition
+import org.apache.commons.lang.math.RandomUtils
+
+class DefinitionBuilder {
+
+    private Definition definition;
+
+    static DefinitionBuilder aDefinition() {
+        def builder = new DefinitionBuilder()
+        builder.definition = new Definition()
+        return builder
+    }
+
+    static DefinitionBuilder aDefinition(id, name, description, version, FieldDefinitionBuilder... fieldDefinitionsBuilder) {
+        def builder = new DefinitionBuilder()
+        builder.definition = new Definition().with {
+            it.id = id
+            it.name = name
+            it.version = version
+            it.description = description
+            it.fieldDefinitions = fieldDefinitionsBuilder.collect { fd -> fd.build() }
+            it
+        }
+        return builder
+    }
+
+    def id(Integer id) {
+        definition.id = id
+        this
+    }
+
+    def name(String name) {
+        definition.name = name
+        this
+    }
+
+    def description(String description) {
+        definition.description = description
+        this
+    }
+
+    def version(Integer version) {
+        definition.version = version
+        this
+    }
+
+    def fieldDefinitions(FieldDefinition... fieldDefinitions) {
+        definition.fieldDefinitions = fieldDefinitions
+        this
+    }
+
+    def fieldDefinitions(FieldDefinitionBuilder... fieldDefinitions) {
+        definition.fieldDefinitions = fieldDefinitions.collect { fd -> fd.build() }
+        this
+    }
+
+    def addFieldDefinitions(FieldDefinition... fieldDefinitions) {
+        fieldDefinitions.each { fd -> definition.fieldDefinitions.add(fd) }
+        this
+    }
+
+    def addFieldDefinitions(FieldDefinitionBuilder... fieldDefinitions) {
+        fieldDefinitions.each { FieldDefinitionBuilder fd -> definition.fieldDefinitions.add(fd.build()) }
+        this
+    }
+
+    Definition build() {
+        definition.with {
+            it.id = it.id ?: RandomUtils.nextInt()
+            it.name = it.name ?: "definition-${it.id}"
+            it.version = it.version ?: 1
+            it.fieldDefinitions = it.fieldDefinitions.collect { fd -> fd.rootField = true; fd } ?: []
+            it
+        }
+    }
+}

--- a/integrationm/test/com/cultofbits/customizations/utils/FieldDefinitionBuilder.groovy
+++ b/integrationm/test/com/cultofbits/customizations/utils/FieldDefinitionBuilder.groovy
@@ -1,0 +1,88 @@
+package com.cultofbits.customizations.utils
+
+
+import com.cultofbits.integrationm.service.dictionary.recordm.FieldDefinition
+import org.apache.commons.lang.math.RandomUtils
+
+class FieldDefinitionBuilder {
+
+    private FieldDefinition fieldDefinition = new FieldDefinition();
+
+    static FieldDefinitionBuilder aFieldDefinition() {
+        def builder = new FieldDefinitionBuilder()
+        builder.fieldDefinition.configuration = new FieldDefinition.Configuration()
+        builder.fieldDefinition.configuration.keys = [:]
+        builder.fieldDefinition.configuration.extensions = [:]
+        return builder
+    }
+
+    static FieldDefinitionBuilder aFieldDefinition(id, name, description, boolean required, boolean duplicable, FieldDefinitionBuilder... childFields) {
+        def builder = new FieldDefinitionBuilder()
+        builder.fieldDefinition.id = id
+        builder.fieldDefinition.name = name
+        builder.fieldDefinition.description = description
+        builder.fieldDefinition.required = required
+        builder.fieldDefinition.duplicable = duplicable
+        builder.fieldDefinition.fields = childFields.collect { cfb -> cfb.build() }.collect { cf -> cf.rootField = false; cf }
+
+        builder.fieldDefinition.configuration = new FieldDefinition.Configuration()
+        builder.fieldDefinition.configuration.keys = [:]
+        builder.fieldDefinition.configuration.extensions = [:]
+
+        return builder
+    }
+
+    def id(Integer id) {
+        fieldDefinition.id = id
+        return this
+    }
+
+    def name(String name) {
+        fieldDefinition.name = name
+        return this
+    }
+
+    def description(String description) {
+        this.fieldDefinition.description = description
+        return this
+    }
+
+    def required(boolean required) {
+        fieldDefinition.required = required
+        return this
+    }
+
+    def duplicable(boolean duplicable) {
+        fieldDefinition.duplicable = duplicable
+        return this
+    }
+
+    def setConfigurationKey(String key, String json) {
+        fieldDefinition.configuration.keys.put(key, json)
+        return this
+    }
+
+    def setConfigurationExtensions(String key, String json) {
+        fieldDefinition.configuration.extensions.put(key, json)
+        return this
+    }
+
+    def childFields(FieldDefinition... childFields) {
+        fieldDefinition.fields = childFields
+        return this
+    }
+
+    def childFields(FieldDefinitionBuilder... childFields) {
+        fieldDefinition.fields = childFields.collect { cf -> cf.build() }
+        return this
+    }
+
+    FieldDefinition build() {
+        fieldDefinition.with {
+            it.id = it.id ?: RandomUtils.nextInt()
+            it.name = it.name ?: "field-definition-${it.id}"
+            it.fields = it.fields ?: []
+            it
+        }
+    }
+}

--- a/integrationm/test/com/cultofbits/customizations/utils/RecordmMsgBuilder.groovy
+++ b/integrationm/test/com/cultofbits/customizations/utils/RecordmMsgBuilder.groovy
@@ -1,0 +1,155 @@
+package com.cultofbits.customizations.utils
+
+import com.cultofbits.integrationm.service.dictionary.recordm.Definition
+import com.cultofbits.integrationm.service.dictionary.recordm.FieldDefinition
+import com.cultofbits.integrationm.service.dictionary.recordm.RecordmMsg
+import org.apache.commons.lang.math.RandomUtils
+
+class RecordmMsgBuilder {
+
+    def msgBody = [
+            _timestamp_: null,
+            id         : null,
+            user       : null,
+            type       : null,
+            action     : null,
+            instance   : [fields: []],
+            oldInstance: [fields: []],
+            diff       : [
+                    "ADDED"        : [],
+                    "VALUE_CHANGED": [],
+                    "VALUE_REMOVED": []
+            ],
+    ]
+
+    static RecordmMsgBuilder aMessage(String user, String type, String action) {
+        def builder = new RecordmMsgBuilder()
+        builder.msgBody.user = user
+        builder.msgBody.type = user
+        builder.msgBody.action = user
+        return builder
+    }
+
+    static RecordmMsgBuilder aMessage(String user, Definition definition, String action) {
+        def builder = new RecordmMsgBuilder()
+        builder.msgBody.user = user
+        builder.msgBody.type = definition.name
+        builder.msgBody.action = action
+        return builder
+    }
+
+    static RecordmMsgBuilder aMessage(String user, Definition definition, String action, Long timestamp) {
+        def builder = new RecordmMsgBuilder()
+        builder.msgBody._timestamp_ = timestamp
+        builder.msgBody.user = user
+        builder.msgBody.type = definition.name
+        builder.msgBody.action = action
+        return builder
+    }
+
+    def newField(Definition definition, Integer fieldDefinitionId, String value) {
+        assert fieldDefinitionId != null
+
+        def fieldDefinition = definition.getField(fieldDefinitionId)
+        assert fieldDefinition != null
+
+        return this.newField(fieldDefinition, null, value)
+    }
+
+    def newField(Definition definition, Integer fieldDefinitionId, Long id, String value) {
+        assert fieldDefinitionId != null
+
+        def fieldDefinition = definition.getField(fieldDefinitionId)
+        assert fieldDefinition != null
+
+        return this.newField(fieldDefinition, id, value)
+    }
+
+    def newField(FieldDefinition fieldDefinition, String value) {
+        return this.newField(fieldDefinition, null, value)
+    }
+
+    def newField(FieldDefinition fieldDefinition, Long id, String value) {
+        return newField([fieldDefinition: fieldDefinition, id: id ?: RandomUtils.nextLong(), value: value])
+    }
+
+    def newField(Map field) {
+        msgBody.instance.fields << field
+        msgBody.diff.ADDED << [field: field.fieldDefinition.name, after: field.value]
+        return this
+    }
+
+
+    def updatedField(Definition definition, Integer fieldDefinitionId, String newValue, String oldValue) {
+        assert fieldDefinitionId != null
+
+        def fieldDefinition = definition.getField(fieldDefinitionId)
+        assert fieldDefinition != null
+
+        return this.updatedField(fieldDefinition, null, newValue, oldValue)
+    }
+
+    def updatedField(Definition definition, Integer fieldDefinitionId, Long id, String newValue, String oldValue) {
+        assert fieldDefinitionId != null
+
+        def fieldDefinition = definition.getField(fieldDefinitionId)
+        assert fieldDefinition != null
+
+        return this.updatedField(fieldDefinition, id, newValue, oldValue)
+    }
+
+    def updatedField(FieldDefinition fieldDefinition, String newValue, String oldValue) {
+        return this.updatedField(fieldDefinition, null, newValue, oldValue)
+    }
+
+    def updatedField(FieldDefinition fieldDefinition, Long id, String newValue, String oldValue) {
+        return this.updatedField([fieldDefinition: fieldDefinition, id: id ?: RandomUtils.nextLong()], newValue, oldValue)
+    }
+
+    def updatedField(Map field, String newValue, String oldValue) {
+        msgBody.instance.fields << ([:] << field).with { it.value = newValue; it }
+        msgBody.oldInstance.fields << ([:] << field).with { it.value = oldValue; it }
+        msgBody.diff.VALUE_CHANGED << [field: field.fieldDefinition.name, after: newValue, before: oldValue]
+        return this
+    }
+
+    def removedField(Definition definition, Integer fieldDefinitionId, String oldValue) {
+        assert fieldDefinitionId != null
+
+        def fieldDefinition = definition.getField(fieldDefinitionId)
+        assert fieldDefinition != null
+
+        return this.removedField(fieldDefinition, null, oldValue)
+    }
+
+    def removedField(Definition definition, Integer fieldDefinitionId, Long id, String oldValue) {
+        assert fieldDefinitionId != null
+
+        def fieldDefinition = definition.getField(fieldDefinitionId)
+        assert fieldDefinition != null
+
+        return this.removedField(fieldDefinition, id, oldValue)
+    }
+
+    def removedField(FieldDefinition fieldDefinition, String oldValue) {
+        return this.removedField(fieldDefinition, null, oldValue)
+    }
+
+    def removedField(FieldDefinition fieldDefinition, Long id, String oldValue) {
+        return this.removedField([fieldDefinition: fieldDefinition, id: id ?: RandomUtils.nextLong()], oldValue)
+    }
+
+    def removedField(Map field, String oldValue) {
+        msgBody.oldInstance.fields << ([:] << field).with { it.value = oldValue; it }
+        msgBody.diff.VALUE_REMOVED << [field: field.fieldDefinition.name, before: oldValue]
+        return this
+    }
+
+    RecordmMsg build() {
+        if (msgBody.id == null) {
+            msgBody.id = new Random().nextInt()
+        }
+
+        new RecordmMsg(msgBody)
+    }
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,3 @@
+cd integrationm && mvn clean compile test
+rm -r target
+rm -r .idea


### PR DESCRIPTION
Only audits the fields that are not autoRef and dont have the argument ignoreRefs as true on the description, for example $audit.updater.time([ignoreRefs:true])